### PR TITLE
Don't require std again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.26", default-features = false, features = ["alloc"] }
 miette = "7.1.0"
 regex-lite = { version = "0.1.0", optional = true }
 serde_json = { version = "1.0.100", default-features = false, features = ["alloc"] }
-winnow = "0.6.18"
+winnow = { version = "0.6.18", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 chrono-tz = { version = "0.8.3", features = ["serde"] }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -1,3 +1,6 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use serde_json::json;
 use winnow::{
     combinator::{alt, cut_err, delimited, fail, preceded, separated, separated_foldl1},

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -1,3 +1,6 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::ops;
 use winnow::ascii::{alpha1, digit1, escaped_transform, take_escaped};
 use winnow::combinator::{alt, opt, repeat};
 use winnow::error::{InputError, ParserError};
@@ -24,7 +27,7 @@ pub enum Token<'a> {
     Float(Float<'a>),
 }
 
-impl<'a> std::fmt::Display for Token<'a> {
+impl<'a> core::fmt::Display for Token<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
     }
@@ -35,15 +38,15 @@ struct Location {
     start: usize,
     end: usize,
 }
-impl From<std::ops::Range<usize>> for Location {
-    fn from(value: std::ops::Range<usize>) -> Self {
+impl From<ops::Range<usize>> for Location {
+    fn from(value: ops::Range<usize>) -> Self {
         Self {
             start: value.start,
             end: value.end,
         }
     }
 }
-impl From<Location> for std::ops::Range<usize> {
+impl From<Location> for ops::Range<usize> {
     fn from(value: Location) -> Self {
         value.start..value.end
     }


### PR DESCRIPTION
Version 0.1.0 didn't require the std library (only alloc). That was lost
in version 0.2.0. Restore that.