### PR TITLE
feat: add date and timestamp literal support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,17 @@
-name: Release
+name: Release Please
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  test:
+  release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: googleapis/release-please-action@v4
         with:
-          submodules: recursive
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Run tests
-        run: cargo test
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
+          release-type: rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/paulredmond/rets_expression/compare/v1.0.1...v1.1.0) (2026-03-24)
+
+
+### Features
+
+* add .ENTRY. and .OLDVALUE. keyword support ([#5](https://github.com/paulredmond/rets_expression/issues/5)) ([36d4f25](https://github.com/paulredmond/rets_expression/commit/36d4f25db49ca0c6dbfab8f0a7c16e851a9623da))
+
 ## [1.0.1](https://github.com/paulredmond/rets_expression/compare/v1.0.0...v1.0.1) (2026-03-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [1.0.1](https://github.com/paulredmond/rets_expression/compare/v1.0.0...v1.0.1) (2026-03-09)
+
+
+### Bug Fixes
+
+* use signed integer arithmetic for NaiveDate day offsets ([d66afb9](https://github.com/paulredmond/rets_expression/commit/d66afb99cbf921005fb2de9fbd756f5e9d4fa242))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Conventions for Claude Code
+
+## Commit messages
+
+All commits MUST use [Conventional Commits](https://www.conventionalcommits.org) format:
+
+```
+<type>: <description>
+```
+
+| Type | Use for | Version bump |
+|------|---------|--------------|
+| `feat` | New functionality | Minor |
+| `fix` | Bug fixes | Patch |
+| `chore` | Maintenance, deps, config | None |
+| `docs` | Documentation only | None |
+| `refactor` | Code change, no behaviour change | None |
+| `test` | Adding or updating tests | None |
+
+For breaking changes, add `BREAKING CHANGE:` in the commit body.
+
+Never use a generic message like "update files" or "fix bug". Always use the conventional format.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rets_expression"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Paul Redmond", "Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "rets_expression"
-version = "0.2.3"
-authors = ["Bryan Burgers <bryan@burgers.io>"]
+version = "1.0.0"
+authors = ["Paul Redmond", "Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"
 description = "Implementation of RETS Validation Expressions from RESO RCP19"
 readme = "README.md"
 documentation = "https://docs.rs/rets_expression"
-homepage = "https://github.com/zenlist/rets_expression"
-repository = "https://github.com/zenlist/rets_expression"
+homepage = "https://github.com/paulredmond/rets_expression"
+repository = "https://github.com/paulredmond/rets_expression"
 keywords = ["rets", "validation", "expression", "reso", "rcp19"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rets_expression"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Paul Redmond", "Bryan Burgers <bryan@burgers.io>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,46 @@ Initialize the compliance test submodule, then run the full test suite:
 git submodule update --init --recursive
 cargo test
 ```
+
+## Releases
+
+Releases are automated via [release-please](https://github.com/googleapis/release-please) using conventional commits.
+
+### Commit message format
+
+Every commit to `main` must use the [Conventional Commits](https://www.conventionalcommits.org) format:
+
+```
+<type>: <description>
+
+# Examples
+feat: add support for negative number literals
+fix: handle NULL in arithmetic expressions
+chore: update winnow to 0.6.20
+docs: add release workflow documentation
+```
+
+| Type | When to use | Version bump |
+|------|-------------|--------------|
+| `feat` | New functionality | Minor (`0.x.0`) |
+| `fix` | Bug fix | Patch (`0.0.x`) |
+| `chore` | Maintenance, dependency updates | None |
+| `docs` | Documentation only | None |
+| `refactor` | Code change with no behaviour change | None |
+| `test` | Adding or updating tests | None |
+
+To trigger a **major** version bump (`x.0.0`), add `BREAKING CHANGE:` in the commit body:
+
+```
+feat: remove deprecated bracket field syntax
+
+BREAKING CHANGE: [FieldName] bracket syntax is no longer supported.
+Use bare FieldName instead.
+```
+
+### How it works
+
+1. Merge commits to `main` using the format above
+2. release-please automatically opens a **Release PR** that bumps the version in `Cargo.toml` and updates `CHANGELOG.md`
+3. Review and merge the Release PR when ready to ship
+4. Merging the Release PR pushes a version tag (e.g. `v0.3.0`), which triggers the release workflow to create a GitHub Release

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ Transport group][transport].
 See [the docs](https://docs.rs/rets_expression) for usage.
 
 This repo tests against the compliance tests at [https://github.com/zenlist/reso-rcp19-compliance-tests](https://github.com/zenlist/reso-rcp19-compliance-tests)
+
+## Running tests
+
+Initialize the compliance test submodule, then run the full test suite:
+
+```sh
+git submodule update --init --recursive
+cargo test
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ See [the docs](https://docs.rs/rets_expression) for usage.
 
 This repo tests against the compliance tests at [https://github.com/zenlist/reso-rcp19-compliance-tests](https://github.com/zenlist/reso-rcp19-compliance-tests)
 
+## Installation
+
+Add to your project's `Cargo.toml` using a specific release tag (recommended):
+
+```toml
+[dependencies]
+rets_expression = { git = "https://github.com/paulredmond/rets_expression", tag = "v1.0.0" }
+```
+
+Or track the latest `main` branch:
+
+```toml
+[dependencies]
+rets_expression = { git = "https://github.com/paulredmond/rets_expression", branch = "main" }
+```
+
+Then run `cargo build` to fetch and compile the dependency.
+
 ## Running tests
 
 Initialize the compliance test submodule, then run the full test suite:

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,7 @@ pub struct EvaluateContext<'engine, 'json, T> {
     engine: &'engine Engine<T>,
     value: &'json Value,
     previous_value: Option<&'json Value>,
+    entry_field: Option<&'json str>,
     state: T,
 }
 
@@ -22,6 +23,7 @@ impl<'engine, 'json> EvaluateContext<'engine, 'json, ()> {
             engine,
             value,
             previous_value: None,
+            entry_field: None,
             state: (),
         }
     }
@@ -33,6 +35,7 @@ impl<'engine, 'json, T> EvaluateContext<'engine, 'json, T> {
         EvaluateContext {
             value,
             previous_value: None,
+            entry_field: None,
             engine,
             state,
         }
@@ -53,6 +56,16 @@ impl<'engine, 'json, T> EvaluateContext<'engine, 'json, T> {
         self
     }
 
+    /// Set the entry field name for evaluating `.ENTRY.` and `.OLDVALUE.` expressions
+    ///
+    /// The entry field is the name of the field that the current rule applies to.
+    /// `.ENTRY.` resolves to this field's current value, and `.OLDVALUE.` resolves
+    /// to this field's previous value.
+    pub fn with_entry_field(mut self, field_name: &'json str) -> Self {
+        self.entry_field = Some(field_name);
+        self
+    }
+
     /// Get a reference to the value within this context
     pub fn value(&self) -> &'json Value {
         self.value
@@ -61,6 +74,11 @@ impl<'engine, 'json, T> EvaluateContext<'engine, 'json, T> {
     /// Get a reference to the previous value within this context, if available
     pub fn previous_value(&self) -> Option<&'json Value> {
         self.previous_value
+    }
+
+    /// Get the entry field name, if set
+    pub fn entry_field(&self) -> Option<&'json str> {
+        self.entry_field
     }
 
     /// Get a reference to the engine used when creating this context

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -88,11 +88,17 @@ impl Expression {
                 serde_json::Value::Bool(true) => writer.write_str(".TRUE."),
                 serde_json::Value::Bool(false) => writer.write_str(".FALSE."),
                 serde_json::Value::Number(n) => writer.write_str(&n.to_string()),
-                serde_json::Value::String(_) => {
-                    let string =
-                        serde_json::to_string(node.value()).map_err(|_| core::fmt::Error)?;
-                    writer.write_str(&string)?;
-                    Ok(())
+                serde_json::Value::String(s) => {
+                    if node.is_date_literal {
+                        writer.write_char('#')?;
+                        writer.write_str(s)?;
+                        writer.write_char('#')
+                    } else {
+                        let string =
+                            serde_json::to_string(node.value()).map_err(|_| core::fmt::Error)?;
+                        writer.write_str(&string)?;
+                        Ok(())
+                    }
                 }
                 serde_json::Value::Array(_) => Err(core::fmt::Error),
                 serde_json::Value::Object(_) => Err(core::fmt::Error),

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -15,6 +15,8 @@ impl Expression {
             Expression::Field(_) => 0,
             Expression::LastField(_) => 0,
             Expression::Literal(_) => 0,
+            Expression::Entry => 0,
+            Expression::OldValue => 0,
             Expression::Function(_) => 1,
             Expression::Iif(_) => 1,
             Expression::List(_) => 1, // TODO: What's the right precedence here?
@@ -137,6 +139,8 @@ impl Expression {
                 writer.write_char(')')?;
                 Ok(())
             }
+            Expression::Entry => writer.write_str(".ENTRY."),
+            Expression::OldValue => writer.write_str(".OLDVALUE."),
         }
     }
 }
@@ -197,6 +201,22 @@ mod tests {
             let parsed = expr.parse::<Expression>().unwrap();
             let serialized = parsed.serialize().unwrap();
             assert_eq!(serialized, expr);
+        }
+    }
+
+    #[test]
+    fn entry_round_trips() {
+        let exprs = [
+            ".ENTRY. = .EMPTY.",
+            ".OLDVALUE. != .EMPTY.",
+            "IIF(ListPrice > 0, .EMPTY., .ENTRY.)",
+            ".OLDVALUE. != .ENTRY.",
+        ];
+
+        for expr in exprs {
+            let parsed = expr.parse::<Expression>().unwrap();
+            let serialized = parsed.serialize().unwrap();
+            assert_eq!(serialized, expr, "round-trip failed for: {expr}");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,13 +582,28 @@ impl From<OpNode> for Expression {
 pub struct LiteralNode {
     /// The literal value
     pub value: Value,
+    /// Whether this literal was written as a date literal (`#YYYY-MM-DD#`)
+    pub is_date_literal: bool,
     span: Option<Span>,
 }
 
 impl LiteralNode {
     /// Create a new node
     pub fn new(value: Value) -> Self {
-        LiteralNode { value, span: None }
+        LiteralNode {
+            value,
+            is_date_literal: false,
+            span: None,
+        }
+    }
+
+    /// Create a new date literal node
+    pub fn new_date(value: Value) -> Self {
+        LiteralNode {
+            value,
+            is_date_literal: true,
+            span: None,
+        }
     }
 
     /// The literal value
@@ -1632,5 +1647,91 @@ mod tests {
         let context = EvaluateContext::new(&engine, &data).with_entry_field("ListingId");
         let result = expression.apply(context).unwrap();
         assert_eq!(result.into_owned(), json!(true));
+    }
+
+    #[test]
+    fn test_date_literal_parse() {
+        let expression = "#2024-01-01#".parse::<Expression>().unwrap();
+        assert_eq!(
+            expression,
+            Expression::Literal(LiteralNode::new_date(json!("2024-01-01")))
+        );
+    }
+
+    #[test]
+    fn test_date_literal_comparison() {
+        let data = json!({ "ListingContractDate": "2024-06-15" });
+        let result = eval("ListingContractDate >= #2024-01-01#", data);
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_date_literal_comparison_false() {
+        let data = json!({ "ListingContractDate": "2023-12-31" });
+        let result = eval("ListingContractDate >= #2024-01-01#", data);
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_date_literal_equality() {
+        let data = json!({ "D": "2024-01-01" });
+        let result = eval("D = #2024-01-01#", data);
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_date_literal_arithmetic_add() {
+        let data = json!({});
+        let result = eval("#2024-01-01# + 30", data);
+        assert_eq!(result, json!("2024-01-31"));
+    }
+
+    #[test]
+    fn test_date_literal_arithmetic_subtract_days() {
+        let data = json!({});
+        let result = eval("#2024-01-31# - 30", data);
+        assert_eq!(result, json!("2024-01-01"));
+    }
+
+    #[test]
+    fn test_date_literal_subtract_dates() {
+        let data = json!({});
+        let result = eval("#2024-01-31# - #2024-01-01#", data);
+        assert_eq!(result, json!(30));
+    }
+
+    #[test]
+    fn test_date_literal_roundtrip() {
+        let expr = "ListingContractDate >= #2024-01-01#";
+        let expression = expr.parse::<Expression>().unwrap();
+        assert_eq!(expression.serialize().unwrap(), expr);
+    }
+
+    #[test]
+    fn test_timestamp_literal_parse() {
+        let expression = "#2024-01-01T10:30:00Z#".parse::<Expression>().unwrap();
+        assert_eq!(
+            expression,
+            Expression::Literal(LiteralNode::new_date(json!("2024-01-01T10:30:00Z")))
+        );
+    }
+
+    #[test]
+    fn test_timestamp_literal_roundtrip() {
+        let expr = "#2024-01-01T10:30:00Z#";
+        let expression = expr.parse::<Expression>().unwrap();
+        assert_eq!(expression.serialize().unwrap(), expr);
+    }
+
+    #[test]
+    fn test_date_literal_invalid_rejected() {
+        let result = "#not-a-date#".parse::<Expression>();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_date_literal_invalid_month_rejected() {
+        let result = "#2024-13-01#".parse::<Expression>();
+        assert!(result.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,9 +847,9 @@ impl ExpressionOp {
 
         fn add_date_number(left: &str, right: &serde_json::Number) -> Result<Value, Error> {
             if let Ok(date) = NaiveDate::parse_from_str(left, "%Y-%m-%d") {
-                let days = right.as_f64().ok_or(Error::InvalidNumber)? as u64;
+                let days = right.as_f64().ok_or(Error::InvalidNumber)? as i64;
                 let new_date = date
-                    .checked_add_days(chrono::Days::new(days))
+                    .checked_add_signed(chrono::Duration::days(days))
                     .ok_or(Error::InvalidType)?;
                 Ok(Value::String(new_date.format("%Y-%m-%d").to_string()))
             } else if let Ok(timestamp) = DateTime::parse_from_rfc3339(left) {
@@ -872,9 +872,9 @@ impl ExpressionOp {
 
         fn subtract_date_number(left: &str, right: &serde_json::Number) -> Result<Value, Error> {
             if let Ok(date) = NaiveDate::parse_from_str(left, "%Y-%m-%d") {
-                let days = right.as_f64().ok_or(Error::InvalidNumber)? as u64;
+                let days = right.as_f64().ok_or(Error::InvalidNumber)? as i64;
                 let new_date = date
-                    .checked_sub_days(chrono::Days::new(days))
+                    .checked_sub_signed(chrono::Duration::days(days))
                     .ok_or(Error::InvalidType)?;
                 Ok(Value::String(new_date.format("%Y-%m-%d").to_string()))
             } else if let Ok(timestamp) = DateTime::parse_from_rfc3339(left) {
@@ -1343,7 +1343,15 @@ pub trait Visitor {
 #[cfg(all(feature = "std", test))]
 mod tests {
     use super::*;
+    use chrono::Local;
     use serde_json::json;
+
+    fn eval(expr: &str, data: serde_json::Value) -> serde_json::Value {
+        let expression = expr.parse::<Expression>().unwrap();
+        let engine = Engine::default();
+        let context = EvaluateContext::new(&engine, &data);
+        expression.apply(context).unwrap().into_owned()
+    }
 
     #[test]
     fn test_basic() {
@@ -1395,5 +1403,95 @@ mod tests {
 
         let serialized = expression.serialize().unwrap();
         assert_eq!(serialized, "5 .IN. LIST(1, 2, Three, LAST Four, Five)");
+    }
+
+    #[test]
+    fn test_add_date_positive_days() {
+        let data = json!({ "D": "2026-01-01" });
+        let result = eval("D + 7", data);
+        assert_eq!(result, json!("2026-01-08"));
+    }
+
+    #[test]
+    fn test_add_date_negative_days() {
+        let data = json!({ "D": "2026-01-08" });
+        let result = eval("D + (0 - 7)", data);
+        assert_eq!(result, json!("2026-01-01"));
+    }
+
+    #[test]
+    fn test_add_date_negative_one() {
+        let data = json!({ "D": "2026-03-01" });
+        let result = eval("D + (0 - 1)", data);
+        assert_eq!(result, json!("2026-02-28"));
+    }
+
+    #[test]
+    fn test_add_date_negative_large() {
+        let data = json!({ "D": "2026-01-01" });
+        let result = eval("D + (0 - 365)", data);
+        assert_eq!(result, json!("2025-01-01"));
+    }
+
+    #[test]
+    fn test_subtract_date_positive_days() {
+        let data = json!({ "D": "2026-01-08" });
+        let result = eval("D - 7", data);
+        assert_eq!(result, json!("2026-01-01"));
+    }
+
+    #[test]
+    fn test_subtract_date_negative_days() {
+        let data = json!({ "D": "2026-01-01" });
+        let result = eval("D - (0 - 7)", data);
+        assert_eq!(result, json!("2026-01-08"));
+    }
+
+    #[test]
+    fn test_date_within_last_7_days_using_negative_addition() {
+        let today = Local::now().date_naive();
+        let three_days_ago = today - chrono::Duration::days(3);
+        let data = json!({ "D": three_days_ago.format("%Y-%m-%d").to_string() });
+        let result = eval("D >= .TODAY. + (0 - 7)", data);
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_date_outside_last_7_days_using_negative_addition() {
+        let today = Local::now().date_naive();
+        let ten_days_ago = today - chrono::Duration::days(10);
+        let data = json!({ "D": ten_days_ago.format("%Y-%m-%d").to_string() });
+        let result = eval("D >= .TODAY. + (0 - 7)", data);
+        assert_eq!(result, json!(false));
+    }
+
+    #[test]
+    fn test_date_range_both_bounds_negative_offset() {
+        let today = Local::now().date_naive();
+        let fifteen_days_ago = today - chrono::Duration::days(15);
+        let data = json!({ "D": fifteen_days_ago.format("%Y-%m-%d").to_string() });
+        let result = eval("D >= .TODAY. + (0 - 30) .AND. D <= .TODAY.", data);
+        assert_eq!(result, json!(true));
+    }
+
+    #[test]
+    fn test_add_date_zero_days() {
+        let data = json!({ "D": "2026-06-15" });
+        let result = eval("D + 0", data);
+        assert_eq!(result, json!("2026-06-15"));
+    }
+
+    #[test]
+    fn test_add_date_negative_crosses_month_boundary() {
+        let data = json!({ "D": "2026-03-05" });
+        let result = eval("D + (0 - 5)", data);
+        assert_eq!(result, json!("2026-02-28"));
+    }
+
+    #[test]
+    fn test_add_date_negative_crosses_year_boundary() {
+        let data = json!({ "D": "2026-01-05" });
+        let result = eval("D + (0 - 10)", data);
+        assert_eq!(result, json!("2025-12-26"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,17 @@ pub enum Expression {
     ///
     /// E.g. `(1, 2, 3)`
     List(ListNode),
+    /// A reference to the current field's value (`.ENTRY.`)
+    ///
+    /// The field is determined by the evaluation context, not the expression itself.
+    /// Use [`EvaluateContext::with_entry_field`] to set the field name before evaluation.
+    Entry,
+    /// A reference to the previous value of the current field (`.OLDVALUE.`)
+    ///
+    /// The field is determined by the evaluation context, not the expression itself.
+    /// Use [`EvaluateContext::with_entry_field`] combined with
+    /// [`EvaluateContext::with_previous`] to set the field name and previous data.
+    OldValue,
 }
 
 impl Expression {
@@ -194,6 +205,12 @@ impl Expression {
                         continue;
                     }
                     visitor.visit_list_expression_out(self);
+                }
+                Expression::Entry => {
+                    visitor.visit_entry_expression(self);
+                }
+                Expression::OldValue => {
+                    visitor.visit_old_value_expression(self);
                 }
             }
             visitor.visit_expression_out(self);
@@ -1167,6 +1184,29 @@ impl Expression {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Cow::Owned(serde_json::json!(args)))
             }
+            Expression::Entry => {
+                let field_name = context
+                    .entry_field()
+                    .ok_or(Error::EntryFieldNotProvided)?;
+                Ok(context
+                    .value()
+                    .get(field_name)
+                    .map(Cow::Borrowed)
+                    .unwrap_or_else(|| Cow::Owned(Value::Null)))
+            }
+            Expression::OldValue => {
+                let field_name = context
+                    .entry_field()
+                    .ok_or(Error::EntryFieldNotProvided)?;
+                if let Some(previous_value) = context.previous_value() {
+                    Ok(previous_value
+                        .get(field_name)
+                        .map(Cow::Borrowed)
+                        .unwrap_or_else(|| Cow::Owned(Value::Null)))
+                } else {
+                    Err(Error::LastUsedWithoutPreviousValue)
+                }
+            }
         }
     }
 }
@@ -1206,6 +1246,8 @@ pub enum Error {
     UnknownFunction(String),
     /// A function call failed
     Function(function::FunctionError),
+    /// `.ENTRY.` or `.OLDVALUE.` was used but no entry field was provided in the context
+    EntryFieldNotProvided,
 }
 
 impl core::fmt::Display for Error {
@@ -1220,6 +1262,9 @@ impl core::fmt::Display for Error {
             Error::DivideByZero => f.write_str("Divide by zero"),
             Error::UnknownFunction(name) => write!(f, "Unknown function: {name}"),
             Error::Function(err) => write!(f, "Error while executing function: {err}"),
+            Error::EntryFieldNotProvided => {
+                f.write_str("`.ENTRY.` or `.OLDVALUE.` was used but no entry field was provided in the context")
+            }
         }
     }
 }
@@ -1338,6 +1383,10 @@ pub trait Visitor {
     fn visit_list_expression_in(&mut self, expression: &mut Expression) {}
     /// Called when the visitor visits an expression representing a [`ListNode`] after visiting its children
     fn visit_list_expression_out(&mut self, expression: &mut Expression) {}
+    /// Called when the visitor visits an `.ENTRY.` expression
+    fn visit_entry_expression(&mut self, expression: &mut Expression) {}
+    /// Called when the visitor visits an `.OLDVALUE.` expression
+    fn visit_old_value_expression(&mut self, expression: &mut Expression) {}
 }
 
 #[cfg(all(feature = "std", test))]
@@ -1493,5 +1542,95 @@ mod tests {
         let data = json!({ "D": "2026-01-05" });
         let result = eval("D + (0 - 10)", data);
         assert_eq!(result, json!("2025-12-26"));
+    }
+
+    #[test]
+    fn test_entry_evaluates_to_field_value() {
+        let expression = ".ENTRY. = .EMPTY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "Remarks": "Hello" });
+        let context = EvaluateContext::new(&engine, &data).with_entry_field("Remarks");
+        let result = expression.apply(context).unwrap();
+        assert_eq!(result.into_owned(), json!(false));
+    }
+
+    #[test]
+    fn test_entry_evaluates_to_null_for_missing_field() {
+        let expression = ".ENTRY. = .EMPTY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({});
+        let context = EvaluateContext::new(&engine, &data).with_entry_field("Remarks");
+        let result = expression.apply(context).unwrap();
+        assert_eq!(result.into_owned(), json!(true));
+    }
+
+    #[test]
+    fn test_entry_errors_without_entry_field() {
+        let expression = ".ENTRY. = .EMPTY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "Remarks": "Hello" });
+        let context = EvaluateContext::new(&engine, &data);
+        let result = expression.apply(context);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_oldvalue_evaluates_to_previous_value() {
+        let expression = ".OLDVALUE. != .ENTRY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "Status": "Active" });
+        let previous = json!({ "Status": "Pending" });
+        let context = EvaluateContext::new(&engine, &data)
+            .with_entry_field("Status")
+            .with_previous(&previous);
+        let result = expression.apply(context).unwrap();
+        assert_eq!(result.into_owned(), json!(true));
+    }
+
+    #[test]
+    fn test_oldvalue_errors_without_previous_value() {
+        let expression = ".OLDVALUE. != .EMPTY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "Status": "Active" });
+        let context = EvaluateContext::new(&engine, &data)
+            .with_entry_field("Status");
+        let result = expression.apply(context);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_oldvalue_errors_without_entry_field() {
+        let expression = ".OLDVALUE. != .EMPTY."
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "Status": "Active" });
+        let previous = json!({ "Status": "Pending" });
+        let context = EvaluateContext::new(&engine, &data)
+            .with_previous(&previous);
+        let result = expression.apply(context);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_entry_in_function_evaluates() {
+        let expression = "STRLEN(CHAR(.ENTRY.)) > 0"
+            .parse::<Expression>()
+            .unwrap();
+        let engine = Engine::default();
+        let data = json!({ "ListingId": "12345" });
+        let context = EvaluateContext::new(&engine, &data).with_entry_field("ListingId");
+        let result = expression.apply(context).unwrap();
+        assert_eq!(result.into_owned(), json!(true));
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -158,6 +158,7 @@ fn prod_exp(input: &mut &[Token<'_>]) -> PResult<Expression> {
 
 fn atom_exp(input: &mut &[Token<'_>]) -> PResult<Expression> {
     alt((
+        unary_minus_exp,
         func_exp,
         collection_exp,
         parenthesized_exp,
@@ -165,6 +166,15 @@ fn atom_exp(input: &mut &[Token<'_>]) -> PResult<Expression> {
         value_exp,
     ))
     .parse_next(input)
+}
+
+fn unary_minus_exp(input: &mut &[Token<'_>]) -> PResult<Expression> {
+    (BinaryOperator::Minus, atom_exp)
+        .map(|(_, inner)| {
+            let zero = Expression::from(LiteralNode::new(serde_json::Value::from(0i64)));
+            Expression::from(OpNode::new(zero, ExpressionOp::Sub, inner))
+        })
+        .parse_next(input)
 }
 
 fn parenthesized_exp(input: &mut &[Token<'_>]) -> PResult<Expression> {
@@ -307,7 +317,8 @@ fn retsname<'a>(input: &mut &[Token<'a>]) -> PResult<Identifier<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::Expression;
+    use crate::{Engine, EvaluateContext, Expression};
+    use serde_json::json;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -367,5 +378,57 @@ mod tests {
         let start = Instant::now();
         let _expression = input.parse::<Expression>().expect("successful parse");
         assert!(start.elapsed() < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_negative_float_in_comparison() {
+        // Regression: `Longitude >= -180.0` previously failed to parse because `-` was always
+        // tokenized as BinaryOperator(Minus) before Float got a chance to include it.
+        "(Longitude >= -180.0) .AND. (Longitude <= 180.0)"
+            .parse::<Expression>()
+            .expect("negative float in comparison should parse");
+    }
+
+    #[test]
+    fn test_negative_int_in_comparison() {
+        "X >= -10"
+            .parse::<Expression>()
+            .expect("negative int in comparison should parse");
+    }
+
+    #[test]
+    fn test_double_negative() {
+        // `0 - -1` should parse as `0 - (0 - 1)` = 1
+        let expr = "0 - -1".parse::<Expression>().expect("double negative should parse");
+        let engine = Engine::default();
+        let context = json!({});
+        let ctx = EvaluateContext::new(&engine, &context);
+        let result = expr.apply(ctx).unwrap();
+        assert_eq!(result.into_owned(), json!(1));
+    }
+
+    #[test]
+    fn test_negative_number_eval() {
+        // `-10 + 5` desugars to `(0 - 10) + 5` = -5
+        let expr = "-10 + 5".parse::<Expression>().expect("should parse");
+        let engine = Engine::default();
+        let context = json!({});
+        let ctx = EvaluateContext::new(&engine, &context);
+        let result = expr.apply(ctx).unwrap();
+        assert_eq!(result.into_owned(), json!(-5));
+    }
+
+    #[test]
+    fn test_negative_float_eval() {
+        // Note: `-180.0` serializes back as `(0 - 180.0)` — round-trip is not symmetric,
+        // but evaluation is correct.
+        let expr = "Longitude >= -180.0"
+            .parse::<Expression>()
+            .expect("should parse");
+        let engine = Engine::default();
+        let context = json!({ "Longitude": -90.0 });
+        let ctx = EvaluateContext::new(&engine, &context);
+        let result = expr.apply(ctx).unwrap();
+        assert_eq!(result.into_owned(), json!(true));
     }
 }

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use serde_json::json;
 use winnow::{
-    combinator::{alt, cut_err, delimited, fail, preceded, separated, separated_foldl1},
+    combinator::{alt, cut_err, delimited, preceded, separated, separated_foldl1},
     prelude::*,
     token::{any, one_of},
     Located,
@@ -282,7 +282,14 @@ fn char_value(input: &mut &[Token<'_>]) -> PResult<Expression> {
 }
 
 fn time_value(input: &mut &[Token<'_>]) -> PResult<Expression> {
-    fail.parse_next(input)
+    any.verify_map(|token: Token<'_>| match token {
+        Token::IsoDate(t) => Some(Expression::from(LiteralNode::new_date(json!(t.value())))),
+        Token::IsoTimestamp(t) => {
+            Some(Expression::from(LiteralNode::new_date(json!(t.value()))))
+        }
+        _ => None,
+    })
+    .parse_next(input)
 }
 
 fn int_value(input: &mut &[Token<'_>]) -> PResult<Expression> {

--- a/src/parser/parse.rs
+++ b/src/parser/parse.rs
@@ -266,6 +266,8 @@ fn spec_value(input: &mut &[Token<'_>]) -> PResult<Expression> {
         )))),
         DottedKeyword::Now.value(Expression::from(FunctionNode::new("NOW", []))),
         DottedKeyword::Today.value(Expression::from(FunctionNode::new("TODAY", []))),
+        DottedKeyword::Entry.value(Expression::Entry),
+        DottedKeyword::OldValue.value(Expression::OldValue),
     ))
     .parse_next(input)
 }
@@ -430,5 +432,40 @@ mod tests {
         let ctx = EvaluateContext::new(&engine, &context);
         let result = expr.apply(ctx).unwrap();
         assert_eq!(result.into_owned(), json!(true));
+    }
+
+    #[test]
+    fn test_entry_parses() {
+        ".ENTRY. = .EMPTY."
+            .parse::<Expression>()
+            .expect(".ENTRY. should parse");
+    }
+
+    #[test]
+    fn test_oldvalue_parses() {
+        ".OLDVALUE. != .EMPTY."
+            .parse::<Expression>()
+            .expect(".OLDVALUE. should parse");
+    }
+
+    #[test]
+    fn test_entry_in_function_call() {
+        "MATCH(CHAR(.ENTRY.), '^[0-9]+$')"
+            .parse::<Expression>()
+            .expect(".ENTRY. inside function call should parse");
+    }
+
+    #[test]
+    fn test_entry_in_iif() {
+        "IIF(ListPrice > 0, .EMPTY., .ENTRY.)"
+            .parse::<Expression>()
+            .expect(".ENTRY. in IIF should parse");
+    }
+
+    #[test]
+    fn test_oldvalue_in_comparison() {
+        ".OLDVALUE. != .ENTRY."
+            .parse::<Expression>()
+            .expect(".OLDVALUE. compared to .ENTRY. should parse");
     }
 }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -224,9 +224,8 @@ pub fn token<'a>(i: &mut Located<&'a str>) -> PResult<Token<'a>> {
         Atom::parse.map(Token::Atom),
         SingleQuotedTerm::parse.map(Token::SingleQuotedTerm),
         DoubleQuotedTerm::parse.map(Token::DoubleQuotedTerm),
-        // double_quoted_term,
-        // iso_timestamp,
-        // iso_date,
+        IsoTimestamp::parse.map(Token::IsoTimestamp),
+        IsoDate::parse.map(Token::IsoDate),
     ))
     .parse_next(i)
 }
@@ -452,6 +451,46 @@ impl<'a> Float<'a> {
         alt((dot_number, number_e, number_dot_number)).parse_next(i)
     }
     pub fn as_str(&self) -> &'a str {
+        self.0
+    }
+}
+
+impl<'a> IsoTimestamp<'a> {
+    fn parse(i: &mut Located<&'a str>) -> PResult<Self> {
+        // #YYYY-MM-DDTHH:MM:SS# with optional fractional seconds and timezone
+        (
+            '#',
+            take_while(1.., |c: char| c != '#'),
+            '#',
+        )
+            .verify(|(_, inner, _): &(char, &str, char)| {
+                chrono::DateTime::parse_from_rfc3339(inner).is_ok()
+            })
+            .map(|(_, inner, _)| IsoTimestamp(inner))
+            .parse_next(i)
+    }
+
+    pub fn value(&self) -> &'a str {
+        self.0
+    }
+}
+
+impl<'a> IsoDate<'a> {
+    fn parse(i: &mut Located<&'a str>) -> PResult<Self> {
+        // #YYYY-MM-DD#
+        (
+            '#',
+            take_while(1.., |c: char| c != '#'),
+            '#',
+        )
+            .verify(|(_, inner, _): &(char, &str, char)| {
+                chrono::NaiveDate::parse_from_str(inner, "%Y-%m-%d").is_ok()
+            })
+            .map(|(_, inner, _)| IsoDate(inner))
+            .parse_next(i)
+    }
+
+    pub fn value(&self) -> &'a str {
         self.0
     }
 }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -135,6 +135,8 @@ pub enum DottedKeyword {
     Null,
     Today,
     Now,
+    Entry,
+    OldValue,
 }
 
 impl<'s, 't, E: ParserError<&'s [Token<'t>]>> Parser<&'s [Token<'t>], DottedKeyword, E>
@@ -288,6 +290,8 @@ impl DottedKeyword {
                 "NULL" => Some(DottedKeyword::Null),
                 "TODAY" => Some(DottedKeyword::Today),
                 "NOW" => Some(DottedKeyword::Now),
+                "ENTRY" => Some(DottedKeyword::Entry),
+                "OLDVALUE" => Some(DottedKeyword::OldValue),
                 _ => None,
             })
             .parse_next(i)


### PR DESCRIPTION
## Summary
- Add support for date literals (`#YYYY-MM-DD#`) and timestamp literals (`#YYYY-MM-DDTHH:MM:SSZ#`) in RCP-019 validation expressions
- Wire up existing `IsoDate`/`IsoTimestamp` token scaffolding through lexer, parser, and formatter
- Date literals participate in all existing operations: comparison, arithmetic (add/subtract days), date subtraction, and round-trip serialization

## Test plan
- [x] Parse date literal `#2024-01-01#` into correct AST node
- [x] Parse timestamp literal `#2024-01-01T10:30:00Z#`
- [x] Date comparison: `ListingContractDate >= #2024-01-01#` (true/false cases)
- [x] Date equality: `D = #2024-01-01#`
- [x] Date arithmetic: `#2024-01-01# + 30` → `"2024-01-31"`
- [x] Date subtraction: `#2024-01-31# - #2024-01-01#` → `30`
- [x] Round-trip serialization preserves `#...#` syntax
- [x] Invalid dates rejected: `#not-a-date#`, `#2024-13-01#`
- [x] All 47 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)